### PR TITLE
Fix APK discovery for multi-flavor variants (#31)

### DIFF
--- a/dta-mcp/src/main/java/io/yamsergey/dta/mcp/McpServer.java
+++ b/dta-mcp/src/main/java/io/yamsergey/dta/mcp/McpServer.java
@@ -968,7 +968,10 @@ public class McpServer {
                 "and launches the main activity. After launch, use layout/network/websocket tools to inspect the app.",
                 schema(Map.of(
                     "project", prop("string", "Absolute path to the Android project root directory", true),
-                    "variant", prop("string", "Build variant (default: debug). Examples: debug, release, stagingDebug", false),
+                    "variant", prop("string", "Build variant in camelCase (default: debug). " +
+                        "Must be a debug variant — sidekick requires debuggable build. " +
+                        "No flavors: debug. " +
+                        "With flavors: stagingDebug, exampleAppUatDebug, freeProductionDebug.", false),
                     "module", prop("string", "Gradle module to build (default: :app)", false),
                     "device", prop("string", "Device serial number (optional, uses default device if omitted)", false)
                 ))),

--- a/tools-android/src/main/java/io/yamsergey/dta/tools/android/runner/AppRunner.java
+++ b/tools-android/src/main/java/io/yamsergey/dta/tools/android/runner/AppRunner.java
@@ -88,6 +88,10 @@ public class AppRunner {
             progress(listener, "INSTALL", "Installing " + packageName + "...");
             connectionManager.installApk(request.device(), apkPath);
 
+            // Brief pause after install — the system needs time to kill the old process
+            // and register the new APK before we can launch
+            Thread.sleep(1000);
+
             // 6. Launch
             progress(listener, "LAUNCH", "Launching " + packageName + "...");
             String component = connectionManager.resolveMainActivity(request.device(), packageName);
@@ -203,21 +207,47 @@ public class AppRunner {
             return null;
         }
 
-        // Search for APKs matching the variant
-        try (Stream<Path> walk = Files.walk(outputDir, 4)) {
+        // Split camelCase variant into segments for path matching.
+        // "exampleAppUatDebug" → ["example", "app", "uat", "debug"]
+        // APK path uses these as directories: exampleApp/uat/debug/app-exampleApp-uat-debug.apk
+        List<String> variantSegments = splitCamelCase(variant);
+
+        // Search for APKs where all variant segments appear in the relative path
+        try (Stream<Path> walk = Files.walk(outputDir, 6)) {
             return walk
                 .filter(p -> p.toString().endsWith(".apk"))
                 .filter(p -> !p.getFileName().toString().contains("androidTest"))
                 .filter(p -> {
-                    // Match variant in path: debug/app-debug.apk or staging/debug/app-staging-debug.apk
                     String rel = outputDir.relativize(p).toString().toLowerCase();
-                    return rel.contains(variant.toLowerCase());
+                    return variantSegments.stream().allMatch(seg -> rel.contains(seg.toLowerCase()));
                 })
                 .map(Path::toAbsolutePath)
                 .map(Path::toString)
                 .findFirst()
                 .orElse(null);
         }
+    }
+
+    /**
+     * Splits a camelCase string into lowercase segments.
+     * "exampleAppUatDebug" → ["example", "app", "uat", "debug"]
+     * "debug" → ["debug"]
+     */
+    private static List<String> splitCamelCase(String s) {
+        List<String> segments = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (Character.isUpperCase(c) && current.length() > 0) {
+                segments.add(current.toString().toLowerCase());
+                current = new StringBuilder();
+            }
+            current.append(c);
+        }
+        if (current.length() > 0) {
+            segments.add(current.toString().toLowerCase());
+        }
+        return segments;
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary
- Fix APK path matching for multi-flavor variants (split camelCase into path segments)
- Add 1s delay after install to fix launch race condition
- Improved MCP tool variant description with multi-flavor examples

## Tested
- CLI: `debug` (single) and `devDebug` (multi-flavor) ✓
- MCP: both variants, cold launch verified ✓

Closes #31