### PR TITLE
Allow overriding launch activity in run_app (#39)

### DIFF
--- a/dta-cli/src/main/java/io/yamsergey/dta/cli/run/RunCommand.java
+++ b/dta-cli/src/main/java/io/yamsergey/dta/cli/run/RunCommand.java
@@ -38,10 +38,15 @@ public class RunCommand implements Callable<Integer> {
             description = "Gradle module (default: :app)")
     private String module;
 
+    @Option(names = {"--activity", "-a"},
+            description = "Activity to launch (default: auto-detected from APK). " +
+                    "Accepts fully-qualified (io.example.MainActivity), relative (.MainActivity), or bare (MainActivity).")
+    private String activity;
+
     @Override
     public Integer call() {
         AppRunner runner = new AppRunner();
-        RunRequest request = new RunRequest(projectPath, deviceSerial, variant, module);
+        RunRequest request = new RunRequest(projectPath, deviceSerial, variant, module, activity);
 
         RunResult result = runner.run(request, (stage, message) -> {
             if ("BUILD".equals(stage)) {

--- a/dta-mcp/src/main/java/io/yamsergey/dta/mcp/McpServer.java
+++ b/dta-mcp/src/main/java/io/yamsergey/dta/mcp/McpServer.java
@@ -973,7 +973,10 @@ public class McpServer {
                         "No flavors: debug. " +
                         "With flavors: stagingDebug, exampleAppUatDebug, freeProductionDebug.", false),
                     "module", prop("string", "Gradle module to build (default: :app)", false),
-                    "device", prop("string", "Device serial number (optional, uses default device if omitted)", false)
+                    "device", prop("string", "Device serial number (optional, uses default device if omitted)", false),
+                    "activity", prop("string", "Activity to launch (optional, auto-detected from APK if omitted). " +
+                        "Accepts fully-qualified (io.example.MainActivity), relative (.MainActivity), or bare (MainActivity). " +
+                        "Use this to override the default launcher when a debug build has multiple launcher activities.", false)
                 ))),
             (exchange, request) -> { var args = request.arguments();
                 try {
@@ -984,10 +987,11 @@ public class McpServer {
                     String module = getString(args, "module");
                     if (module == null) module = ":app";
                     String device = getString(args, "device");
+                    String activity = getString(args, "activity");
 
                     var runner = new io.yamsergey.dta.tools.android.runner.AppRunner();
                     var req = new io.yamsergey.dta.tools.android.runner.AppRunner.RunRequest(
-                        project, device, variant, module);
+                        project, device, variant, module, activity);
 
                     var result = runner.run(req, (stage, message) ->
                         log.debug("[{}] {}", stage, message));

--- a/tools-android/src/main/java/io/yamsergey/dta/tools/android/runner/AppRunner.java
+++ b/tools-android/src/main/java/io/yamsergey/dta/tools/android/runner/AppRunner.java
@@ -27,12 +27,14 @@ public class AppRunner {
         String projectPath,
         String device,
         String variant,
-        String module
+        String module,
+        String activity
     ) {
         public RunRequest {
             if (projectPath == null || projectPath.isEmpty()) throw new IllegalArgumentException("projectPath required");
             if (variant == null || variant.isEmpty()) variant = "debug";
             if (module == null || module.isEmpty()) module = ":app";
+            if (activity != null && activity.isEmpty()) activity = null;
         }
     }
 
@@ -93,18 +95,19 @@ public class AppRunner {
             // and register the new APK before we can launch
             Thread.sleep(1000);
 
-            // 6. Launch — use launcher activity from APK metadata (aapt2)
-            // rather than device-side resolve-activity, which can pick the wrong
-            // activity when debug builds have multiple launcher activities
+            // 6. Launch — priority: user override → aapt2 launchable-activity → device resolve-activity.
+            // aapt2 is preferred over resolve-activity because debug builds sometimes have multiple
+            // launcher activities and resolve-activity picks the wrong one.
             progress(listener, "LAUNCH", "Launching " + packageName + "...");
             String component;
-            if (apkInfo.launcherActivity() != null) {
+            if (request.activity() != null) {
+                component = packageName + "/" + normalizeActivity(request.activity());
+            } else if (apkInfo.launcherActivity() != null) {
                 component = packageName + "/" + apkInfo.launcherActivity();
-                connectionManager.launchActivity(request.device(), component);
             } else {
                 component = connectionManager.resolveMainActivity(request.device(), packageName);
-                connectionManager.launchActivity(request.device(), component);
             }
+            connectionManager.launchActivity(request.device(), component);
             log.info("Launched: {}", component);
 
             return new RunResult(true, packageName, apkPath, buildLog.toString(), component, null);
@@ -349,6 +352,17 @@ public class AppRunner {
     private static String capitalize(String s) {
         if (s == null || s.isEmpty()) return s;
         return Character.toUpperCase(s.charAt(0)) + s.substring(1);
+    }
+
+    /**
+     * Normalizes an activity name for use in {@code am start -n package/activity}.
+     * Accepts fully-qualified ({@code io.example.MainActivity}), relative ({@code .MainActivity}),
+     * or bare ({@code MainActivity}). Bare names get a leading dot so {@code am start} resolves
+     * them against the package.
+     */
+    private static String normalizeActivity(String activity) {
+        if (activity.contains(".")) return activity;
+        return "." + activity;
     }
 
     private static void progress(ProgressListener listener, String stage, String message) {


### PR DESCRIPTION
Closes #39

## Summary

- Adds optional `activity` parameter to `AppRunner.RunRequest`, propagated through both `dta-cli run --activity` and the MCP `run_app` tool
- When set, bypasses aapt2 detection and launches the given activity directly
- Accepts fully-qualified (`io.example.MainActivity`), relative (`.MainActivity`), or bare (`MainActivity`) — bare names get normalized with a leading dot

## Launch priority

1. User-supplied `activity` (if set)
2. aapt2 `launchable-activity` from APK badging
3. Device-side `resolve-activity` (fallback)

## Test plan

Verified end-to-end on `emulator-5554` with `test-fixtures/android-projects/agp/8.13/compose-example`:

- [x] CLI `--activity .MainActivity` → launched `pkg/.MainActivity`
- [x] CLI `--activity MainActivity` (bare) → normalized to `pkg/.MainActivity`
- [x] CLI `--activity .DoesNotExist` → override reached `am start` (proves not falling through to aapt2)
- [x] MCP `run_app` with `activity=.MainActivity` → `launchActivity: pkg/.MainActivity`
- [x] MCP `run_app` with `activity=MainActivity` → normalized to `pkg/.MainActivity`
- [x] MCP `run_app` with `activity=.DoesNotExist` → override propagated
- [x] `./gradlew :tools-android:compileJava :dta-cli:compileJava :dta-mcp:compileJava` passes

## Notes

Pre-existing side finding (not fixed here): `SidekickConnectionManager.launchActivity()` doesn't surface `am start`'s exit-1 when the activity doesn't exist on device — `run_app` returns `success: true` even for a bogus activity. Worth filing as a follow-up if strict error reporting is desired.